### PR TITLE
fixed typo config_3x2pt_pure_Cell.ini

### DIFF
--- a/config_files/config_3x2pt_pure_Cell.ini
+++ b/config_files/config_3x2pt_pure_Cell.ini
@@ -588,7 +588,7 @@ lower_calc_limit = 1e-200
 ;                      tomo_i and tomo_j can run from 0 to n-1 or 1 to n. M mass sample bins, these should agree with the number of bins chosen for the bias section
 ;                      Parameter: filename as string.
 ;                           MUST contain 'gm' or 'gkappa'
-;   Cmm_file:          File for the galaxy matter angular power spectrum (GGL). The file should be organised as follows
+;   Cmm_file:          File for the matter matter angular power spectrum. The file should be organised as follows
 ;                               ell        tomo_i       tomo_j           Cmm_ij (ell)  
 ;                                2            1            1                   ...
 ;                                2            1            2                   ...


### PR DESCRIPTION
Had galaxy matter instead of matter matter in the Cls section of the docstring. Fixed that.